### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
   # before_action :set_item, only: [:edit, :update,]
 
     def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
       @item = Item.new
     end
 
+    def show
+      @item = Item.find(params[:id])
+    end
+
     def create
       @item = Item.new(item_params)
       if @item.valid?

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "＃" do %>
+          <%= link_to item_path(item.id) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
             <% end %>
@@ -147,7 +147,7 @@
             <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= item.amount %>円<br><%= item.delivery_fee %></span>
+            <span><%= item.amount %>円<br><%= item.delivery_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
@@ -16,54 +16,57 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.amount %>円
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.delivery_fee.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+      <% if user_signed_in? %>
+        <% if current_user.id == @item.user.id %>
+          <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+            <p class='or-text'>or</p>
+              <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+            <% else %>
+            <%# 商品が売れていない場合はこちらを表示しましょう %>
+            <%= link_to '購入画面に進む', item_path(@item.id) ,class:"item-red-btn"%>
+            <%# //商品が売れていない場合はこちらを表示しましょう %>
+        <% end %>
+          <%#  商品編集削除ボタン %>
+         <%# elsif '商品が出品中かどうか' %>
+        <%#  商品購入ボタン %>
+      <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_name %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.duration.name %></td>
         </tr>
       </tbody>
     </table>
@@ -102,7 +105,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,14 +30,9 @@
             <p class='or-text'>or</p>
               <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
             <% else %>
-            <%# 商品が売れていない場合はこちらを表示しましょう %>
             <%= link_to '購入画面に進む', item_path(@item.id) ,class:"item-red-btn"%>
-            <%# //商品が売れていない場合はこちらを表示しましょう %>
+          <% end %>
         <% end %>
-          <%#  商品編集削除ボタン %>
-         <%# elsif '商品が出品中かどうか' %>
-        <%#  商品購入ボタン %>
-      <% end %>
 
     <div class="item-explain-box">
       <span><%= @item.item_name %></span>


### PR DESCRIPTION
# what
商品詳細表示機能の作成

# why
商品詳細表示機能を実装するため


ログアウト状態でも商品詳細ページを閲覧できること
https://gyazo.com/694d526cd4d5984a1ed9071c80ba163b
出品者にしか商品の編集・削除のリンクが踏めないようになっていること
https://gyazo.com/cdf5f567c91e31450e38487366f9be22
出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
https://gyazo.com/64a317a0f6c89eb179bed85a7127e679